### PR TITLE
Dev/brpanask/fixes2

### DIFF
--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/AscOperations_Get.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/AscOperations_Get.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "subscriptionId": "613192d7-503f-477a-9cfe-4efc3ee2bd60",
+    "location": "West US",
+    "operationId": "testoperationid",
+    "api-version": "2020-10-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/id/locations/westus/ascOperations/testoperationid",
+        "name": "testoperationid",
+        "startTime": "2020-03-01T13:13:13.933Z",
+        "endTime": "2020-03-01T16:13:13.933Z",
+        "status": "Succeeded"
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_CreateOrUpdate.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_CreateOrUpdate.json
@@ -27,6 +27,51 @@
     }
   },
   "responses": {
+    "202": {
+      "body": {
+        "tags": {
+          "Dept": "ContosoAds"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1",
+        "location": "westus",
+        "name": "sc1",
+        "type": "Microsoft.StorageCache/Cache",
+        "properties": {
+          "cacheSizeGB": 3072,
+          "health": {
+            "state": "Transitioning",
+            "statusDescription": "Cache is being created."
+          },
+          "mountAddresses": [
+            "192.168.1.1",
+            "192.168.1.2"
+          ],
+          "provisioningState": "Succeeded",
+          "subnet": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.Network/virtualNetworks/scvnet/subnets/sub1",
+          "upgradeStatus": {
+            "currentFirmwareVersion": "5.3.23",
+            "firmwareUpdateStatus": "available",
+            "firmwareUpdateDeadline": "2019-04-21T18:25:43.511Z",
+            "lastFirmwareUpdate": "2019-01-21T18:25:43.511Z",
+            "pendingFirmwareVersion": "5.3.24"
+          },
+          "networkSettings": {
+            "mtu": 1500
+          },
+          "encryptionSettings": {
+            "keyEncryptionKey": {
+              "keyUrl": "https://keyvault-cmk.vault.azure.net/keys/key2048/test",
+              "sourceVault": {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.KeyVault/vaults/keyvault-cmk"
+              }
+            }
+          }
+        },
+        "sku": {
+          "name": "Standard_2G"
+        }
+      }
+    },
     "201": {
       "body": {
         "tags": {

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_CreateOrUpdate.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_CreateOrUpdate.json
@@ -1,0 +1,121 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "cacheName": "sc1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01",
+    "cache": {
+      "tags": {
+        "Dept": "ContosoAds"
+      },
+      "location": "westus",
+      "properties": {
+        "cacheSizeGB": 3072,
+        "subnet": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.Network/virtualNetworks/scvnet/subnets/sub1"
+      },
+      "encryptionSettings": {
+        "keyEncryptionKey": {
+          "keyUrl": "https://keyvault-cmk.vault.azure.net/keys/key2048/test",
+          "sourceVault": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.KeyVault/vaults/keyvault-cmk"
+          }
+        }
+      },
+      "sku": {
+        "name": "Standard_2G"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "tags": {
+          "Dept": "ContosoAds"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1",
+        "location": "westus",
+        "name": "sc1",
+        "type": "Microsoft.StorageCache/Cache",
+        "properties": {
+          "cacheSizeGB": 3072,
+          "health": {
+            "state": "Transitioning",
+            "statusDescription": "Cache is being created."
+          },
+          "mountAddresses": [
+            "192.168.1.1",
+            "192.168.1.2"
+          ],
+          "provisioningState": "Succeeded",
+          "subnet": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.Network/virtualNetworks/scvnet/subnets/sub1",
+          "upgradeStatus": {
+            "currentFirmwareVersion": "5.3.23",
+            "firmwareUpdateStatus": "available",
+            "firmwareUpdateDeadline": "2019-04-21T18:25:43.511Z",
+            "lastFirmwareUpdate": "2019-01-21T18:25:43.511Z",
+            "pendingFirmwareVersion": "5.3.24"
+          },
+          "networkSettings": {
+            "mtu": 1500
+          },
+          "encryptionSettings": {
+            "keyEncryptionKey": {
+              "keyUrl": "https://keyvault-cmk.vault.azure.net/keys/key2048/test",
+              "sourceVault": {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.KeyVault/vaults/keyvault-cmk"
+              }
+            }
+          }
+        },
+        "sku": {
+          "name": "Standard_2G"
+        }
+      }
+    },
+    "200": {
+      "body": {
+        "tags": {
+          "Dept": "ContosoAds"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1",
+        "location": "westus",
+        "name": "sc1",
+        "type": "Microsoft.StorageCache/Cache",
+        "properties": {
+          "cacheSizeGB": 3072,
+          "health": {
+            "state": "Transitioning",
+            "statusDescription": "Cache is being created."
+          },
+          "mountAddresses": [
+            "192.168.1.1",
+            "192.168.1.2"
+          ],
+          "provisioningState": "Updating",
+          "subnet": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.Network/virtualNetworks/scvnet/subnets/sub1",
+          "upgradeStatus": {
+            "currentFirmwareVersion": "V5.1.12",
+            "firmwareUpdateStatus": "available",
+            "firmwareUpdateDeadline": "2019-04-21T18:25:43.511Z",
+            "lastFirmwareUpdate": "2019-01-21T18:25:43.511Z",
+            "pendingFirmwareVersion": "V5.1.15"
+          },
+          "networkSettings": {
+            "mtu": 1500
+          },
+          "encryptionSettings": {
+            "keyEncryptionKey": {
+              "keyUrl": "https://keyvault-cmk.vault.azure.net/keys/key2048/test",
+              "sourceVault": {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.KeyVault/vaults/keyvault-cmk"
+              }
+            }
+          }
+        },
+        "sku": {
+          "name": "Standard_2G"
+        }
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_Delete.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "cacheName": "sc",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01"
+  },
+  "responses": {
+    "200": {
+      "body": ""
+    },
+    "202": {
+      "body": ""
+    },
+    "204": {
+      "body": ""
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_Flush.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_Flush.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "cacheName": "sc",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01"
+  },
+  "responses": {
+    "200": {
+      "body": ""
+    },
+    "202": {
+      "body": ""
+    },
+    "204": {
+      "body": ""
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_Get.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_Get.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "cacheName": "sc1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "tags": {
+          "Dept": "ContosoAds"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1",
+        "location": "westus",
+        "name": "sc1",
+        "type": "Microsoft.StorageCache/Cache",
+        "properties": {
+          "cacheSizeGB": 3072,
+          "health": {
+            "state": "Transitioning",
+            "statusDescription": "Cache is being created."
+          },
+          "mountAddresses": [
+            "192.168.1.1",
+            "192.168.1.2"
+          ],
+          "provisioningState": "Succeeded",
+          "subnet": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.Network/virtualNetworks/scvnet/subnets/sub1",
+          "upgradeStatus": {
+            "currentFirmwareVersion": "V5.1.12",
+            "firmwareUpdateStatus": "available",
+            "firmwareUpdateDeadline": "2019-04-21T18:25:43.511Z",
+            "lastFirmwareUpdate": "2019-01-21T18:25:43.511Z",
+            "pendingFirmwareVersion": "V5.1.15"
+          },
+          "networkSettings": {
+            "mtu": 1500
+          },
+          "encryptionSettings": {
+            "keyEncryptionKey": {
+              "keyUrl": "https://keyvault-cmk.vault.azure.net/keys/key2048/test",
+              "sourceVault": {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.KeyVault/vaults/keyvault-cmk"
+              }
+            }
+          }
+        },
+        "sku": {
+          "name": "Standard_2G"
+        }
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_List.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_List.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "tags": {
+              "Dept": "ContosoAds"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1",
+            "location": "westus",
+            "name": "sc1",
+            "type": "Microsoft.StorageCache/Cache",
+            "properties": {
+              "cacheSizeGB": 3072,
+              "health": {
+                "state": "Transitioning",
+                "statusDescription": "Cache is being created."
+              },
+              "mountAddresses": [
+                "192.168.1.1",
+                "192.168.1.2"
+              ],
+              "provisioningState": "Succeeded",
+              "subnet": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.Network/virtualNetworks/scvnet/subnets/sub1",
+              "upgradeStatus": {
+                "currentFirmwareVersion": "V5.1.12",
+                "firmwareUpdateStatus": "available",
+                "firmwareUpdateDeadline": "2019-04-21T18:25:43.511Z",
+                "lastFirmwareUpdate": "2019-01-21T18:25:43.511Z",
+                "pendingFirmwareVersion": "V5.1.15"
+              },
+              "networkSettings": {
+                "mtu": 1500
+              },
+              "encryptionSettings": {
+                "keyEncryptionKey": {
+                  "keyUrl": "https://keyvault-cmk.vault.azure.net/keys/key2048/test",
+                  "sourceVault": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.KeyVault/vaults/keyvault-cmk"
+                  }
+                }
+              }
+            },
+            "sku": {
+              "name": "Standard_2G"
+            }
+          },
+          {
+            "tags": {
+              "Dept": "ContosoAds"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc2",
+            "location": "westus",
+            "name": "sc2",
+            "type": "Microsoft.StorageCache/Cache",
+            "properties": {
+              "cacheSizeGB": 3072,
+              "health": {
+                "state": "Transitioning",
+                "statusDescription": "Cache is being created."
+              },
+              "mountAddresses": [
+                "192.168.1.1",
+                "192.168.1.2"
+              ],
+              "provisioningState": "Updating",
+              "subnet": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.Network/virtualNetworks/scvnet/subnets/sub2",
+              "upgradeStatus": {
+                "currentFirmwareVersion": "V5.1.12",
+                "firmwareUpdateStatus": "available",
+                "firmwareUpdateDeadline": "2019-04-21T18:25:43.511Z",
+                "lastFirmwareUpdate": "2019-01-21T18:25:43.511Z",
+                "pendingFirmwareVersion": "V5.1.15"
+              },
+              "networkSettings": {
+                "mtu": 1500
+              },
+              "encryptionSettings": {
+                "keyEncryptionKey": {
+                  "keyUrl": "https://keyvault-cmk.vault.azure.net/keys/key2048/test",
+                  "sourceVault": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.KeyVault/vaults/keyvault-cmk"
+                  }
+                }
+              }
+            },
+            "sku": {
+              "name": "Standard_2G"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_ListByResourceGroup.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_ListByResourceGroup.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "tags": {
+              "Dept": "ContosoAds"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1",
+            "location": "westus",
+            "name": "sc1",
+            "type": "Microsoft.StorageCache/Cache",
+            "properties": {
+              "cacheSizeGB": 3072,
+              "health": {
+                "state": "Transitioning",
+                "statusDescription": "Cache is being created."
+              },
+              "mountAddresses": [
+                "192.168.1.1",
+                "192.168.1.2"
+              ],
+              "provisioningState": "Succeeded",
+              "subnet": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.Network/virtualNetworks/scvnet/subnets/sub1",
+              "upgradeStatus": {
+                "currentFirmwareVersion": "V5.1.12",
+                "firmwareUpdateStatus": "available",
+                "firmwareUpdateDeadline": "2019-04-21T18:25:43.511Z",
+                "lastFirmwareUpdate": "2019-01-21T18:25:43.511Z",
+                "pendingFirmwareVersion": "V5.1.15"
+              },
+              "networkSettings": {
+                "mtu": 1500
+              },
+              "encryptionSettings": {
+                "keyEncryptionKey": {
+                  "keyUrl": "https://keyvault-cmk.vault.azure.net/keys/key2048/test",
+                  "sourceVault": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.KeyVault/vaults/keyvault-cmk"
+                  }
+                }
+              }
+            },
+            "sku": {
+              "name": "Standard_2G"
+            }
+          },
+          {
+            "tags": {
+              "Dept": "ContosoAds"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc2",
+            "location": "westus",
+            "name": "sc2",
+            "type": "Microsoft.StorageCache/Cache",
+            "properties": {
+              "cacheSizeGB": 3072,
+              "health": {
+                "state": "Transitioning",
+                "statusDescription": "Cache is being created."
+              },
+              "mountAddresses": [
+                "192.168.1.1",
+                "192.168.1.2"
+              ],
+              "provisioningState": "Updating",
+              "subnet": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.Network/virtualNetworks/scvnet/subnets/sub2",
+              "upgradeStatus": {
+                "currentFirmwareVersion": "V5.1.12",
+                "firmwareUpdateStatus": "available",
+                "firmwareUpdateDeadline": "2019-04-21T18:25:43.511Z",
+                "lastFirmwareUpdate": "2019-01-21T18:25:43.511Z",
+                "pendingFirmwareVersion": "V5.1.15"
+              },
+              "networkSettings": {
+                "mtu": 1500
+              },
+              "encryptionSettings": {
+                "keyEncryptionKey": {
+                  "keyUrl": "https://keyvault-cmk.vault.azure.net/keys/key2048/test",
+                  "sourceVault": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.KeyVault/vaults/keyvault-cmk"
+                  }
+                }
+              }
+            },
+            "sku": {
+              "name": "Standard_2G"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_Start.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_Start.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "cacheName": "sc",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01"
+  },
+  "responses": {
+    "200": {
+      "body": ""
+    },
+    "202": {
+      "body": ""
+    },
+    "204": {
+      "body": ""
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_Stop.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_Stop.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "cacheName": "sc",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01"
+  },
+  "responses": {
+    "200": {
+      "body": ""
+    },
+    "202": {
+      "body": ""
+    },
+    "204": {
+      "body": ""
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_Update.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_Update.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "cacheName": "sc1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01",
+    "cache": {
+      "tags": {
+        "Dept": "ContosoAds"
+      },
+      "location": "westus",
+      "properties": {
+        "cacheSizeGB": 3072,
+        "subnet": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.Network/virtualNetworks/scvnet/subnets/sub1",
+        "networkSettings" : {
+          "mtu": 1400
+        },
+        "securitySettings" : {
+          "rootSquash" : true
+        }
+      },
+      "sku": {
+        "name": "Standard_2G"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "tags": {
+          "Dept": "ContosoAds"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1",
+        "location": "westus",
+        "name": "sc1",
+        "type": "Microsoft.StorageCache/Cache",
+        "properties": {
+          "cacheSizeGB": 3072,
+          "health": {
+            "state": "Transitioning",
+            "statusDescription": "Cache is being created."
+          },
+          "mountAddresses": [
+            "192.168.1.1",
+            "192.168.1.2"
+          ],
+          "provisioningState": "Updating",
+          "subnet": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.Network/virtualNetworks/scvnet/subnets/sub1",
+          "upgradeStatus": {
+            "currentFirmwareVersion": "V5.1.12",
+            "firmwareUpdateStatus": "available",
+            "firmwareUpdateDeadline": "2019-04-21T18:25:43.511Z",
+            "lastFirmwareUpdate": "2019-01-21T18:25:43.511Z",
+            "pendingFirmwareVersion": "V5.1.15"
+          },
+          "networkSettings": {
+            "mtu": 1400
+          },
+          "securitySettings": {
+            "rootSquash" : true
+          }
+        },
+        "sku": {
+          "name": "Standard_2G"
+        }
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_UpgradeFirmware.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Caches_UpgradeFirmware.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "cacheName": "sc1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01"
+  },
+  "responses": {
+    "201": {
+      "body": ""
+    },
+    "202": {
+      "body": ""
+    },
+    "204": {
+      "body": ""
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Operations_List.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Operations_List.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2020-10-01",
+    "x-ms-client-request-id": [
+      "7e655b68-e491-4cb6-90c3-6a5b10b7bd17"
+    ],
+    "accept-language": [
+      "en-US"
+    ]
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.StorageCache/caches/write",
+            "display": {
+              "operation": "Create or Update Cache",
+              "provider": "Azure Storage Cache",
+              "resource": "Caches"
+            }
+          },
+          {
+            "name": "Microsoft.StorageCache/caches/delete",
+            "display": {
+              "operation": "Delete Cache",
+              "provider": "Azure Storage Cache",
+              "resource": "Caches"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Skus_List.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/Skus_List.json
@@ -1,0 +1,86 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "resourceType": "caches",
+            "name": "Standard_2G",
+            "locations": [
+              "East US"
+            ],
+            "locationInfo": [
+              {
+                "location": "East US",
+                "zones": []
+              }
+            ],
+            "capabilities": [
+              {
+                "name": "throughput GB/s",
+                "value": "2"
+              },
+              {
+                "name": "cache sizes(GB)",
+                "value": "3072,6144,12288"
+              }
+            ],
+            "restrictions": []
+          },
+          {
+            "resourceType": "caches",
+            "name": "Standard_4G",
+            "locations": [
+              "East US"
+            ],
+            "locationInfo": [
+              {
+                "location": "East US",
+                "zones": []
+              }
+            ],
+            "capabilities": [
+              {
+                "name": "throughput GB/s",
+                "value": "4"
+              },
+              {
+                "name": "cache sizes(GB)",
+                "value": "6144,12288,24576"
+              }
+            ],
+            "restrictions": []
+          },
+          {
+            "resourceType": "caches",
+            "name": "Standard_8G",
+            "locations": [
+              "East US"
+            ],
+            "locationInfo": [
+              {
+                "location": "East US",
+                "zones": []
+              }
+            ],
+            "capabilities": [
+              {
+                "name": "throughput GB/s",
+                "value": "8"
+              },
+              {
+                "name": "cache sizes(GB)",
+                "value": "12288,24576,49152"
+              }
+            ],
+            "restrictions": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_CreateOrUpdate.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_CreateOrUpdate.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01",
+    "cacheName": "sc1",
+    "storageTargetName": "st1",
+    "storagetarget": {
+      "properties": {
+        "junctions": [
+          {
+            "namespacePath": "/path/on/cache",
+            "targetPath": "/path/on/exp1",
+            "nfsExport": "exp1"
+          },
+          {
+            "namespacePath": "/path2/on/cache",
+            "targetPath": "/path2/on/exp2",
+            "nfsExport": "exp2"
+          }
+        ],
+        "targetType": "nfs3",
+        "nfs3": {
+          "target": "10.0.44.44",
+          "usageModel": "READ_HEAVY_INFREQ"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "st1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1/storagetargets/st1",
+        "type": "Microsoft.StorageCache/Cache/StorageTarget",
+        "properties": {
+          "junctions": [
+            {
+              "namespacePath": "/path/on/cache",
+              "targetPath": "/path/on/exp1",
+              "nfsExport": "exp1"
+            },
+            {
+              "namespacePath": "/path2/on/cache",
+              "targetPath": "/path2/on/exp2",
+              "nfsExport": "exp2"
+            }
+          ],
+          "targetType": "nfs3",
+          "nfs3": {
+            "target": "10.0.44.44",
+            "usageModel": "READ_HEAVY_INFREQ"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "st1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1/storagetargets/st1",
+        "type": "Microsoft.StorageCache/Cache/StorageTarget",
+        "properties": {
+          "junctions": [
+            {
+              "namespacePath": "/path/on/cache",
+              "targetPath": "/path/on/exp1",
+              "nfsExport": "exp1"
+            },
+            {
+              "namespacePath": "/path2/on/cache",
+              "targetPath": "/path2/on/exp2",
+              "nfsExport": "exp2"
+            }
+          ],
+          "targetType": "nfs3",
+          "nfs3": {
+            "target": "10.0.44.44",
+            "usageModel": "READ_HEAVY_INFREQ"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_CreateOrUpdate.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_CreateOrUpdate.json
@@ -79,6 +79,32 @@
           }
         }
       }
+    },
+    "202": {
+      "body": {
+        "name": "st1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1/storagetargets/st1",
+        "type": "Microsoft.StorageCache/Cache/StorageTarget",
+        "properties": {
+          "junctions": [
+            {
+              "namespacePath": "/path/on/cache",
+              "targetPath": "/path/on/exp1",
+              "nfsExport": "exp1"
+            },
+            {
+              "namespacePath": "/path2/on/cache",
+              "targetPath": "/path2/on/exp2",
+              "nfsExport": "exp2"
+            }
+          ],
+          "targetType": "nfs3",
+          "nfs3": {
+            "target": "10.0.44.44",
+            "usageModel": "READ_HEAVY_INFREQ"
+          }
+        }
+      }
     }
   }
 }

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_CreateOrUpdate_NoJunctions.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_CreateOrUpdate_NoJunctions.json
@@ -44,24 +44,12 @@
         }
       }
     },
-    "201": {
+    "202": {
       "body": {
         "name": "st1",
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1/storagetargets/st1",
         "type": "Microsoft.StorageCache/Cache/StorageTarget",
         "properties": {
-          "junctions": [
-            {
-              "namespacePath": "/path/on/cache",
-              "targetPath": "/path/on/exp1",
-              "nfsExport": "exp1"
-            },
-            {
-              "namespacePath": "/path2/on/cache",
-              "targetPath": "/path2/on/exp2",
-              "nfsExport": "exp2"
-            }
-          ],
           "targetType": "nfs3",
           "nfs3": {
             "target": "10.0.44.44",

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_CreateOrUpdate_NoJunctions.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_CreateOrUpdate_NoJunctions.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01",
+    "cacheName": "sc1",
+    "storageTargetName": "st1",
+    "storagetarget": {
+      "properties": {
+        "targetType": "nfs3",
+        "nfs3": {
+          "target": "10.0.44.44",
+          "usageModel": "READ_HEAVY_INFREQ"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "st1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1/storagetargets/st1",
+        "type": "Microsoft.StorageCache/Cache/StorageTarget",
+        "properties": {
+          "targetType": "nfs3",
+          "nfs3": {
+            "target": "10.0.44.44",
+            "usageModel": "READ_HEAVY_INFREQ"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "st1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1/storagetargets/st1",
+        "type": "Microsoft.StorageCache/Cache/StorageTarget",
+        "properties": {
+          "targetType": "nfs3",
+          "nfs3": {
+            "target": "10.0.44.44",
+            "usageModel": "READ_HEAVY_INFREQ"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_CreateOrUpdate_NoJunctions.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_CreateOrUpdate_NoJunctions.json
@@ -43,6 +43,32 @@
           }
         }
       }
+    },
+    "201": {
+      "body": {
+        "name": "st1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1/storagetargets/st1",
+        "type": "Microsoft.StorageCache/Cache/StorageTarget",
+        "properties": {
+          "junctions": [
+            {
+              "namespacePath": "/path/on/cache",
+              "targetPath": "/path/on/exp1",
+              "nfsExport": "exp1"
+            },
+            {
+              "namespacePath": "/path2/on/cache",
+              "targetPath": "/path2/on/exp2",
+              "nfsExport": "exp2"
+            }
+          ],
+          "targetType": "nfs3",
+          "nfs3": {
+            "target": "10.0.44.44",
+            "usageModel": "READ_HEAVY_INFREQ"
+          }
+        }
+      }
     }
   }
 }

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_Delete.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01",
+    "cacheName": "sc1",
+    "storageTargetName": "st1"
+  },
+  "responses": {
+    "200": {
+      "body": ""
+    },
+    "202": {
+      "body": ""
+    },
+    "204": {
+      "body": ""
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_Get.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01",
+    "cacheName": "sc1",
+    "storageTargetName": "st1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "st1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1/storagetargets/st1",
+        "type": "Microsoft.StorageCache/Cache/StorageTarget",
+        "properties": {
+          "junctions": [
+            {
+              "namespacePath": "/path/on/cache",
+              "targetPath": "/path/on/exp1",
+              "nfsExport": "exp1"
+            },
+            {
+              "namespacePath": "/path2/on/cache",
+              "targetPath": "/path2/on/exp2",
+              "nfsExport": "exp2"
+            }
+          ],
+          "targetType": "nfs3",
+          "nfs3": {
+            "target": "10.0.44.44",
+            "usageModel": "READ_HEAVY_FREQ"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_ListByCache.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/StorageTargets_ListByCache.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "resourceGroupName": "scgroup",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01",
+    "cacheName": "sc1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "st1",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1/storagetargets/st1",
+            "type": "Microsoft.StorageCache/Cache/StorageTarget",
+            "properties": {
+              "junctions": [
+                {
+                  "namespacePath": "/path/on/cache",
+                  "targetPath": "/path/on/exp1",
+                  "nfsExport": "exp1"
+                },
+                {
+                  "namespacePath": "/path2/on/cache",
+                  "targetPath": "/path2/on/exp2",
+                  "nfsExport": "exp2"
+                }
+              ],
+              "targetType": "nfs3",
+              "nfs3": {
+                "target": "10.0.44.44",
+                "usageModel": "READ_HEAVY_FREQ"
+              }
+            }
+          },
+          {
+            "name": "st2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1/storagetargets/st2",
+            "type": "Microsoft.StorageCache/Cache/StorageTarget",
+            "properties": {
+              "junctions": [
+                {
+                  "namespacePath": "/some/crazy/place/on/cache",
+                  "targetPath": "/"
+                }
+              ],
+              "targetType": "clfs",
+              "clfs": {
+                "target": "https://atj5c2fc9b8c00.blob.core.windows.net/atj5c2fc9b8c01"
+              }
+            }
+          },
+          {
+            "name": "st3",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scgroup/providers/Microsoft.StorageCache/caches/sc1/storagetargets/st3",
+            "type": "Microsoft.StorageCache/Cache/StorageTarget",
+            "properties": {
+              "junctions": [
+                {
+                  "namespacePath": "/some/crazier/place/on/cache",
+                  "targetPath": "/",
+                  "nfsExport": ""
+                }
+              ],
+              "targetType": "unknown",
+              "unknown": {
+                "unknownMap": {
+                  "foo": "bar",
+                  "foo2": "test"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/UsageModels_List.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/examples/UsageModels_List.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2020-10-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "modelName": "READ_HEAVY_INFREQ",
+            "targetType": "nfs3",
+            "display": {
+              "description": "Read heavy, infrequent changes"
+            }
+          },
+          {
+            "modelName": "WRITE_AROUND",
+            "targetType": "nfs3",
+            "display": {
+              "description": "Clients write directly to storage"
+            }
+          },
+          {
+            "modelName": "WRITE_WORKLOAD_15",
+            "targetType": "nfs3",
+            "display": {
+              "description": "Write workload > 15%"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/storagecache.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2020-10-01/storagecache.json
@@ -1,0 +1,1836 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "A Storage Cache provides scalable caching service for NAS clients, serving data from either NFSv3 or Blob at-rest storage (referred to as \"Storage Targets\"). These operations allow you to manage Caches.",
+    "title": "Storage Cache Mgmt Client",
+    "version": "2020-10-01"
+  },
+  "host": "management.azure.com",
+  "basePath": "/",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/providers/Microsoft.StorageCache/operations": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of available Resource Provider operations.",
+            "schema": {
+              "$ref": "#/definitions/ApiOperationListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "tags": [
+          "Operations"
+        ],
+        "description": "Lists all of the available Resource Provider operations.",
+        "x-ms-examples": {
+          "StorageTargets_List": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "operationId": "Operations_List",
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.StorageCache/skus": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of SKU descriptors.",
+            "schema": {
+              "$ref": "#/definitions/ResourceSkusResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Skus_List": {
+            "$ref": "./examples/Skus_List.json"
+          }
+        },
+        "tags": [
+          "SKUs"
+        ],
+        "description": "Get the list of StorageCache.Cache SKUs available to this subscription.",
+        "operationId": "Skus_List"
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.StorageCache/usageModels": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of UsageModel descriptors.",
+            "schema": {
+              "$ref": "#/definitions/UsageModelsResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "UsageModels_List": {
+            "$ref": "./examples/UsageModels_List.json"
+          }
+        },
+        "tags": [
+          "UsageModels"
+        ],
+        "description": "Get the list of Cache Usage Models available to this subscription.",
+        "operationId": "UsageModels_List"
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.StorageCache/locations/{location}/ascOperations/{operationId}": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The region name which the operation will lookup into."
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The operation id which uniquely identifies the asynchronous operation."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Gets the status of an asynchronous operation for the Azure HPC cache",
+            "schema": {
+              "$ref": "#/definitions/AscOperation"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AscOperations_Get": {
+            "$ref": "./examples/AscOperations_Get.json"
+          }
+        },
+        "tags": [
+          "AscOperations"
+        ],
+        "description": "Gets the status of an asynchronous operation for the Azure HPC cache",
+        "operationId": "AscOperations_Get"
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.StorageCache/caches": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of Cache objects. Note that entity references might replace complete Cache objects, as described in http://docs.oasis-open.org/odata/odata-json-format/v4.01/cs01/odata-json-format-v4.01-cs01.html#sec_EntityReference",
+            "schema": {
+              "$ref": "#/definitions/CachesListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Caches_List": {
+            "$ref": "./examples/Caches_List.json"
+          }
+        },
+        "tags": [
+          "Caches"
+        ],
+        "description": "Returns all Caches the user has access to under a subscription.",
+        "operationId": "Caches_List"
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of Cache objects. Note that entity references might replace complete Cache objects, as described in http://docs.oasis-open.org/odata/odata-json-format/v4.01/cs01/odata-json-format-v4.01-cs01.html#sec_EntityReference",
+            "schema": {
+              "$ref": "#/definitions/CachesListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Caches_ListByResourceGroup": {
+            "$ref": "./examples/Caches_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "tags": [
+          "Caches"
+        ],
+        "description": "Returns all Caches the user has access to under a resource group.",
+        "operationId": "Caches_ListByResourceGroup"
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}": {
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of Cache. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "cacheName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cache deleted.",
+            "schema": {}
+          },
+          "202": {
+            "description": "Started the Cache's transition to Deleted state. Poll the Cache to monitor.",
+            "schema": {}
+          },
+          "204": {
+            "description": "Cache deleted.",
+            "schema": {}
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Caches_Delete": {
+            "$ref": "./examples/Caches_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "tags": [
+          "Caches"
+        ],
+        "description": "Schedules a Cache for deletion.",
+        "operationId": "Caches_Delete"
+      },
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of Cache. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "cacheName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the Cache object corresponding to cacheName.",
+            "schema": {
+              "$ref": "#/definitions/Cache"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Caches_Get": {
+            "$ref": "./examples/Caches_Get.json"
+          }
+        },
+        "tags": [
+          "Caches"
+        ],
+        "description": "Returns a Cache.",
+        "operationId": "Caches_Get"
+      },
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "description": "Name of Cache. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "cacheName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Object containing the user-selectable properties of the new Cache. If read-only properties are included, they must match the existing values of those properties.",
+            "in": "body",
+            "name": "cache",
+            "schema": {
+              "$ref": "#/definitions/Cache"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cache created or updated.",
+            "schema": {
+              "$ref": "#/definitions/Cache"
+            }
+          },
+          "201": {
+            "description": "Cache creation or update has been initiated. Poll the new Cache's provisioningState property to monitor creation progress.",
+            "schema": {
+              "$ref": "#/definitions/Cache"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Caches_CreateOrUpdate": {
+            "$ref": "./examples/Caches_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "tags": [
+          "Caches"
+        ],
+        "description": "Create or update a Cache.",
+        "operationId": "Caches_CreateOrUpdate"
+      },
+      "patch": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "description": "Name of Cache. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "cacheName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Object containing the user-selectable properties of the Cache. If read-only properties are included, they must match the existing values of those properties.",
+            "in": "body",
+            "name": "cache",
+            "schema": {
+              "$ref": "#/definitions/Cache"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated the Cache.",
+            "schema": {
+              "$ref": "#/definitions/Cache"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Caches_Update": {
+            "$ref": "./examples/Caches_Update.json"
+          }
+        },
+        "tags": [
+          "Caches"
+        ],
+        "description": "Update a Cache instance.",
+        "operationId": "Caches_Update"
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/flush": {
+      "post": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "description": "Name of Cache. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "cacheName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All cached data has been flushed to the Storage Target(s).",
+            "schema": {}
+          },
+          "202": {
+            "description": "Cache has started flushing to its Storage Target(s). Poll the Cache's state field to monitor.",
+            "schema": {}
+          },
+          "204": {
+            "description": "Cache flush already in progress or has completed.",
+            "schema": {}
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Caches_Flush": {
+            "$ref": "./examples/Caches_Flush.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "tags": [
+          "Caches"
+        ],
+        "description": "Tells a Cache to write all dirty data to the Storage Target(s). During the flush, clients will see errors returned until the flush is complete.",
+        "operationId": "Caches_Flush"
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/start": {
+      "post": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "description": "Name of Cache. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "cacheName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cache is Active.",
+            "schema": {}
+          },
+          "202": {
+            "description": "Cache has started the transition to Active. Poll the Cache's state field to monitor.",
+            "schema": {}
+          },
+          "204": {
+            "description": "Restarted VMs associated with the cache.",
+            "schema": {}
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Caches_Start": {
+            "$ref": "./examples/Caches_Start.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "tags": [
+          "Caches"
+        ],
+        "description": "Tells a Stopped state Cache to transition to Active state.",
+        "operationId": "Caches_Start"
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/stop": {
+      "post": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "description": "Name of Cache. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "cacheName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cache is stopped.",
+            "schema": {}
+          },
+          "202": {
+            "description": "Cache has started the transition to Stopped. Poll the Cache's state field to monitor.",
+            "schema": {}
+          },
+          "204": {
+            "description": "Stopped VMs associated with the cache.",
+            "schema": {}
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Caches_Stop": {
+            "$ref": "./examples/Caches_Stop.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "tags": [
+          "Caches"
+        ],
+        "description": "Tells an Active Cache to transition to Stopped state.",
+        "operationId": "Caches_Stop"
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/storageTargets": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "description": "Name of Cache. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "cacheName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the list of Storage Targets defined by cacheName.",
+            "schema": {
+              "$ref": "#/definitions/StorageTargetsResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageTargets_List": {
+            "$ref": "./examples/StorageTargets_ListByCache.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "tags": [
+          "StorageTargets"
+        ],
+        "description": "Returns a list of Storage Targets for the specified Cache.",
+        "operationId": "StorageTargets_ListByCache"
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/storageTargets/{storageTargetName}": {
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "description": "Name of Cache. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "cacheName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of Storage Target.",
+            "in": "path",
+            "name": "storageTargetName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Storage target deleted.",
+            "schema": {}
+          },
+          "202": {
+            "description": "Started the Storage Target's deletion. Poll the Cache's Storage Targets to monitor.",
+            "schema": {}
+          },
+          "204": {
+            "description": "Storage Target deleted.",
+            "schema": {}
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageTargets_Delete": {
+            "$ref": "./examples/StorageTargets_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "tags": [
+          "StorageTargets"
+        ],
+        "description": "Removes a Storage Target from a Cache. This operation is allowed at any time, but if the Cache is down or unhealthy, the actual removal of the Storage Target may be delayed until the Cache is healthy again. Note that if the Cache has data to flush to the Storage Target, the data will be flushed before the Storage Target will be deleted.",
+        "operationId": "StorageTargets_Delete"
+      },
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "description": "Name of Cache. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "cacheName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the Storage Target. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "storageTargetName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the Storage Target object corresponding to storageTargetName.",
+            "schema": {
+              "$ref": "#/definitions/StorageTarget"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageTargets_Get": {
+            "$ref": "./examples/StorageTargets_Get.json"
+          }
+        },
+        "tags": [
+          "StorageTargets"
+        ],
+        "description": "Returns a Storage Target from a Cache.",
+        "operationId": "StorageTargets_Get"
+      },
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "description": "Name of Cache. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "cacheName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the Storage Target. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "storageTargetName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Object containing the definition of a Storage Target.",
+            "in": "body",
+            "name": "storagetarget",
+            "schema": {
+              "$ref": "#/definitions/StorageTarget"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Storage Target has been created or updated.",
+            "schema": {
+              "$ref": "#/definitions/StorageTarget"
+            }
+          },
+          "201": {
+            "description": "Storage Target creation or update has been initiated. Poll the new Storage Target's provisioningState property to monitor creation progress.",
+            "schema": {
+              "$ref": "#/definitions/StorageTarget"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageTargets_CreateOrUpdate": {
+            "$ref": "./examples/StorageTargets_CreateOrUpdate.json"
+          },
+          "StorageTargets_CreateOrUpdate_NoJunctions": {
+            "$ref": "./examples/StorageTargets_CreateOrUpdate_NoJunctions.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "tags": [
+          "StorageTargets"
+        ],
+        "description": "Create or update a Storage Target. This operation is allowed at any time, but if the Cache is down or unhealthy, the actual creation/modification of the Storage Target may be delayed until the Cache is healthy again.",
+        "operationId": "StorageTargets_CreateOrUpdate"
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/upgrade": {
+      "post": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Target resource group.",
+            "in": "path",
+            "name": "resourceGroupName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "description": "Name of Cache. Length of name must be not greater than 80 and chars must be in list of [-0-9a-zA-Z_] char class.",
+            "in": "path",
+            "name": "cacheName",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Cache firmware is up to date.",
+            "schema": {}
+          },
+          "202": {
+            "description": "Cache has started the upgrade. Poll the Cache's state field to monitor.",
+            "schema": {}
+          },
+          "204": {
+            "description": "Cache firmware is up to date.",
+            "schema": {}
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Caches_UpgradeFirmware": {
+            "$ref": "./examples/Caches_UpgradeFirmware.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "tags": [
+          "Caches"
+        ],
+        "description": "Upgrade a Cache's firmware if a new version is available. Otherwise, this operation has no effect.",
+        "operationId": "Caches_UpgradeFirmware"
+      }
+    }
+  },
+  "definitions": {
+    "ApiOperation": {
+      "description": "REST API operation description: see https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/openapi-authoring-automated-guidelines.md#r3023-operationsapiimplementation",
+      "properties": {
+        "display": {
+          "description": "The object that represents the operation.",
+          "properties": {
+            "operation": {
+              "description": "Operation type: Read, write, delete, etc.",
+              "type": "string"
+            },
+            "provider": {
+              "description": "Service provider: Microsoft.StorageCache",
+              "type": "string"
+            },
+            "resource": {
+              "description": "Resource on which the operation is performed: Cache, etc.",
+              "type": "string"
+            }
+          }
+        },
+        "name": {
+          "description": "Operation name: {provider}/{resource}/{operation}",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ApiOperationListResult": {
+      "description": "Result of the request to list Resource Provider operations. It contains a list of operations and a URL link to get the next set of results.",
+      "properties": {
+        "nextLink": {
+          "description": "URL to get the next set of operation list results if there are any.",
+          "type": "string"
+        },
+        "value": {
+          "description": "List of Resource Provider operations supported by the Microsoft.StorageCache resource provider.",
+          "items": {
+            "$ref": "#/definitions/ApiOperation"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "CloudError": {
+      "x-ms-external": true,
+      "description": "An error response.",
+      "properties": {
+        "error": {
+          "description": "The body of the error.",
+          "$ref": "#/definitions/CloudErrorBody"
+        }
+      },
+      "type": "object"
+    },
+    "CloudErrorBody": {
+      "description": "An error response.",
+      "properties": {
+        "code": {
+          "description": "An identifier for the error. Codes are invariant and are intended to be consumed programmatically.",
+          "type": "string"
+        },
+        "details": {
+          "description": "A list of additional details about the error.",
+          "items": {
+            "$ref": "#/definitions/CloudErrorBody"
+          },
+          "type": "array"
+        },
+        "message": {
+          "description": "A message describing the error, intended to be suitable for display in a user interface.",
+          "type": "string"
+        },
+        "target": {
+          "description": "The target of the particular error. For example, the name of the property in error.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "AscOperation": {
+      "description": "The status of operation.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The operation Id."
+        },
+        "name": {
+          "type": "string",
+          "description": "The operation name."
+        },
+        "startTime": {
+          "type": "string",
+          "description": "The start time of the operation."
+        },
+        "endTime": {
+          "type": "string",
+          "description": "The end time of the operation."
+        },
+        "status": {
+          "type": "string",
+          "description": "The status of the operation."
+        },
+        "error": {
+          "type": "object",
+          "description": "The error detail of the operation if any.",
+          "$ref": "#/definitions/ErrorResponse"
+        }
+      }
+    },
+    "ErrorResponse": {
+      "description": "Describes the format of Error response.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "Error code",
+          "type": "string"
+        },
+        "message": {
+          "description": "Error message indicating why the operation failed.",
+          "type": "string"
+        }
+      }
+    },
+    "Cache": {
+      "description": "A Cache instance. Follows Azure Resource Manager standards: https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md",
+      "properties": {
+        "tags": {
+          "description": "ARM tags as name/value pairs.",
+          "type": "object"
+        },
+        "id": {
+          "description": "Resource ID of the Cache.",
+          "readOnly": true,
+          "$ref": "#/definitions/URLString"
+        },
+        "location": {
+          "description": "Region name string.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of Cache.",
+          "readOnly": true,
+          "$ref": "#/definitions/ResourceName"
+        },
+        "type": {
+          "description": "Type of the Cache; Microsoft.StorageCache/Cache",
+          "readOnly": true,
+          "type": "string"
+        },
+        "identity": {
+          "$ref": "#/definitions/CacheIdentity",
+          "description": "The identity of the cache, if configured."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "description": "Properties of the Cache.",
+          "properties": {
+            "cacheSizeGB": {
+              "description": "The size of this Cache, in GB.",
+              "type": "integer"
+            },
+            "health": {
+              "description": "Health of the Cache.",
+              "readOnly": true,
+              "$ref": "#/definitions/CacheHealth"
+            },
+            "mountAddresses": {
+              "description": "Array of IP addresses that can be used by clients mounting this Cache.",
+              "readOnly": true,
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "provisioningState": {
+              "description": "ARM provisioning state, see https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/Addendum.md#provisioningstate-property",
+              "enum": [
+                "Succeeded",
+                "Failed",
+                "Cancelled",
+                "Creating",
+                "Deleting",
+                "Updating"
+              ],
+              "x-ms-enum": {
+                "name": "ProvisioningStateType",
+                "modelAsString": true
+              },
+              "type": "string"
+            },
+            "subnet": {
+              "description": "Subnet used for the Cache.",
+              "$ref": "#/definitions/URLString"
+            },
+            "upgradeStatus": {
+              "description": "Upgrade status of the Cache.",
+              "$ref": "#/definitions/CacheUpgradeStatus"
+            },
+            "networkSettings": {
+              "$ref": "#/definitions/CacheNetworkSettings",
+              "description": "Specifies network settings of the cache."
+            },
+            "encryptionSettings": {
+              "$ref": "#/definitions/CacheEncryptionSettings",
+              "description": "Specifies encryption settings of the cache."
+            },
+            "securitySettings": {
+              "$ref": "#/definitions/CacheSecuritySettings",
+              "description": "Specifies security settings of the cache."
+            }
+          },
+          "type": "object"
+        },
+        "sku": {
+          "description": "SKU for the Cache.",
+          "properties": {
+            "name": {
+              "description": "SKU name for this Cache.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "x-ms-azure-resource": true,
+      "type": "object"
+    },
+    "CacheIdentity": {
+      "description": "Cache identity properties.",
+      "properties": {
+        "principalId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The principal id of the cache."
+        },
+        "tenantId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The tenant id associated with the cache."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of identity used for the cache",
+          "enum": [
+            "SystemAssigned",
+            "None"
+          ],
+          "x-ms-enum": {
+            "name": "CacheIdentityType",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "CacheNetworkSettings": {
+      "description": "Cache network settings.",
+      "properties": {
+        "mtu": {
+          "description": "The IPv4 maximum transmission unit configured for the subnet.",
+          "type": "integer",
+          "minimum": 576,
+          "maximum": 1500,
+          "default": 1500
+        },
+        "utilityAddresses": {
+          "description": "Array of additional IP addresses used by this Cache.",
+          "readOnly": true,
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "CacheEncryptionSettings": {
+      "description": "Cache encryption settings.",
+      "properties": {
+        "keyEncryptionKey": {
+          "x-ms-secret": true,
+          "$ref": "#/definitions/KeyVaultKeyReference",
+          "description": "Specifies the location of the key encryption key in Key Vault."
+        }
+      }
+    },
+    "CacheSecuritySettings": {
+      "description": "Cache security settings.",
+      "properties": {
+        "rootSquash": {
+          "type": "boolean",
+          "description": "root squash of cache property."
+        }
+      }
+    },
+    "KeyVaultKeyReference": {
+      "description": "Describes a reference to Key Vault Key.",
+      "properties": {
+        "keyUrl": {
+          "type": "string",
+          "description": "The URL referencing a key encryption key in Key Vault."
+        },
+        "sourceVault": {
+          "description": "Describes a resource Id to source Key Vault.",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Resource Id."
+            }
+          }
+        }
+      },
+      "required": [
+        "keyUrl",
+        "sourceVault"
+      ]
+    },
+    "CachesListResult": {
+      "description": "Result of the request to list Caches. It contains a list of Caches and a URL link to get the next set of results.",
+      "properties": {
+        "nextLink": {
+          "description": "URL to get the next set of Cache list results, if there are any.",
+          "type": "string"
+        },
+        "value": {
+          "description": "List of Caches.",
+          "items": {
+            "$ref": "#/definitions/Cache"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "CacheHealth": {
+      "description": "An indication of Cache health. Gives more information about health than just that related to provisioning.",
+      "properties": {
+        "state": {
+          "description": "List of Cache health states.",
+          "enum": [
+            "Unknown",
+            "Healthy",
+            "Degraded",
+            "Down",
+            "Transitioning",
+            "Stopping",
+            "Stopped",
+            "Upgrading",
+            "Flushing"
+          ],
+          "x-ms-enum": {
+            "name": "HealthStateType",
+            "modelAsString": true
+          },
+          "type": "string"
+        },
+        "statusDescription": {
+          "description": "Describes explanation of state.",
+          "type": "string"
+        }
+      }
+    },
+    "CacheUpgradeStatus": {
+      "description": "Properties describing the software upgrade state of the Cache.",
+      "properties": {
+        "currentFirmwareVersion": {
+          "description": "Version string of the firmware currently installed on this Cache.",
+          "type": "string",
+          "readOnly": true
+        },
+        "firmwareUpdateStatus": {
+          "description": "True if there is a firmware update ready to install on this Cache. The firmware will automatically be installed after firmwareUpdateDeadline if not triggered earlier via the upgrade operation.",
+          "enum": [
+            "available",
+            "unavailable"
+          ],
+          "x-ms-enum": {
+            "name": "FirmwareStatusType",
+            "modelAsString": true
+          },
+          "readOnly": true,
+          "type": "string"
+        },
+        "firmwareUpdateDeadline": {
+          "description": "Time at which the pending firmware update will automatically be installed on the Cache.",
+          "format": "date-time",
+          "type": "string",
+          "readOnly": true
+        },
+        "lastFirmwareUpdate": {
+          "description": "Time of the last successful firmware update.",
+          "format": "date-time",
+          "type": "string",
+          "readOnly": true
+        },
+        "pendingFirmwareVersion": {
+          "description": "When firmwareUpdateAvailable is true, this field holds the version string for the update.",
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "type": "object"
+    },
+    "UnknownProperties": {
+      "description": "Properties of an unknown type of Storage Target.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "StorageTarget": {
+      "type": "object",
+      "description": "Type of the Storage Target.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StorageTargetResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "description": "StorageTarget properties",
+          "$ref": "#/definitions/StorageTargetProperties"
+        }
+      }
+    },
+    "StorageTargetResource": {
+      "description": "Resource used by a Cache.",
+      "properties": {
+        "name": {
+          "description": "Name of the Storage Target.",
+          "readOnly": true,
+          "$ref": "#/definitions/ResourceName"
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource ID of the Storage Target."
+        },
+        "type": {
+          "description": "Type of the Storage Target; Microsoft.StorageCache/Cache/StorageTarget",
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "StorageTargetProperties": {
+      "type": "object",
+      "description": "Properties of the Storage Target.",
+      "required": [
+        "targetType"
+      ],
+      "properties": {
+        "junctions": {
+          "description": "List of Cache namespace junctions to target for namespace associations.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NamespaceJunction"
+          }
+        },
+        "targetType": {
+          "description": "Type of the Storage Target.",
+          "enum": [
+            "nfs3",
+            "clfs",
+            "unknown"
+          ],
+          "x-ms-enum": {
+            "name": "StorageTargetType",
+            "modelAsString": true
+          },
+          "type": "string"
+        },
+        "provisioningState": {
+          "description": "ARM provisioning state, see https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/Addendum.md#provisioningstate-property",
+          "enum": [
+            "Succeeded",
+            "Failed",
+            "Cancelled",
+            "Creating",
+            "Deleting",
+            "Updating"
+          ],
+          "x-ms-enum": {
+            "name": "ProvisioningStateType",
+            "modelAsString": true
+          },
+          "type": "string"
+        },
+        "nfs3": {
+          "description": "Properties when targetType is nfs3.",
+          "$ref": "#/definitions/Nfs3Target"
+        },
+        "clfs": {
+          "description": "Properties when targetType is clfs.",
+          "$ref": "#/definitions/ClfsTarget"
+        },
+        "unknown": {
+          "description": "Properties when targetType is unknown.",
+          "$ref": "#/definitions/UnknownTarget"
+        }
+      }
+    },
+    "Nfs3Target": {
+      "description": "Properties pertained to Nfs3Target",
+      "properties": {
+        "target": {
+          "description": "IP address or host name of an NFSv3 host (e.g., 10.0.44.44).",
+          "pattern": "^[-.0-9a-zA-Z]+$",
+          "type": "string"
+        },
+        "usageModel": {
+          "description": "Identifies the primary usage model to be used for this Storage Target. Get choices from .../usageModels",
+          "type": "string"
+        }
+      }
+    },
+    "ClfsTarget": {
+      "description": "Properties pertained to ClfsTarget",
+      "properties": {
+        "target": {
+          "description": "Resource ID of storage container.",
+          "$ref": "#/definitions/URLString"
+        }
+      }
+    },
+    "UnknownTarget": {
+      "description": "Properties pertained to UnknownTarget",
+      "properties": {
+        "unknownMap": {
+          "description": "Dictionary of string->string pairs containing information about the Storage Target.",
+          "$ref": "#/definitions/UnknownProperties"
+        }
+      }
+    },
+    "ResourceName": {
+      "description": "Schema for the name of resources served by this provider. Note that objects will contain an odata @id annotation as appropriate. This will contain the complete URL of the object. These names are case-preserving, but not case sensitive.",
+      "pattern": "^[-0-9a-zA-Z_]{1,80}$",
+      "type": "string"
+    },
+    "ResourceSku": {
+      "description": "A resource SKU.",
+      "properties": {
+        "resourceType": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of resource the SKU applies to."
+        },
+        "capabilities": {
+          "description": "A list of capabilities of this SKU, such as throughput or ops/sec.",
+          "items": {
+            "$ref": "#/definitions/ResourceSkuCapabilities"
+          },
+          "type": "array"
+        },
+        "locations": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The set of locations that the SKU is available. This will be supported and registered Azure Geo Regions (e.g., West US, East US, Southeast Asia, etc.)."
+        },
+        "locationInfo": {
+          "description": "The set of locations that the SKU is available.",
+          "items": {
+            "$ref": "#/definitions/ResourceSkuLocationInfo"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "The name of this SKU.",
+          "type": "string"
+        },
+        "restrictions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Restriction"
+          },
+          "description": "The restrictions preventing this SKU from being used. This is empty if there are no restrictions."
+        }
+      },
+      "type": "object"
+    },
+    "Restriction": {
+      "properties": {
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of restrictions. In this version, the only possible value for this is location."
+        },
+        "values": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The value of restrictions. If the restriction type is set to location, then this would be the different locations where the SKU is restricted."
+        },
+        "reasonCode": {
+          "type": "string",
+          "enum": [
+            "QuotaId",
+            "NotAvailableForSubscription"
+          ],
+          "x-ms-enum": {
+            "name": "ReasonCode",
+            "modelAsString": true
+          },
+          "description": "The reason for the restriction. As of now this can be \"QuotaId\" or \"NotAvailableForSubscription\". \"QuotaId\" is set when the SKU has requiredQuotas parameter as the subscription does not belong to that quota. \"NotAvailableForSubscription\" is related to capacity at the datacenter."
+        }
+      },
+      "description": "The restrictions preventing this SKU from being used."
+    },
+    "ResourceSkuCapabilities": {
+      "description": "A resource SKU capability.",
+      "properties": {
+        "name": {
+          "description": "Name of a capability, such as ops/sec.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Quantity, if the capability is measured by quantity.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ResourceSkuLocationInfo": {
+      "description": "Resource SKU location information.",
+      "properties": {
+        "location": {
+          "description": "Location where this SKU is available.",
+          "type": "string"
+        },
+        "zones": {
+          "description": "Zones if any.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "type": "object"
+    },
+    "ResourceSkusResult": {
+      "description": "The response from the List Cache SKUs operation.",
+      "properties": {
+        "nextLink": {
+          "description": "The URI to fetch the next page of Cache SKUs.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The list of SKUs available for the subscription.",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/ResourceSku"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "NamespaceJunction": {
+      "description": "A namespace junction.",
+      "type": "object",
+      "properties": {
+        "namespacePath": {
+          "description": "Namespace path on a Cache for a Storage Target.",
+          "type": "string"
+        },
+        "targetPath": {
+          "description": "Path in Storage Target to which namespacePath points.",
+          "type": "string"
+        },
+        "nfsExport": {
+          "description": "NFS export where targetPath exists.",
+          "type": "string"
+        }
+      }
+    },
+    "StorageTargetsResult": {
+      "description": "A list of Storage Targets.",
+      "properties": {
+        "nextLink": {
+          "description": "The URI to fetch the next page of Storage Targets.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The list of Storage Targets defined for the Cache.",
+          "items": {
+            "$ref": "#/definitions/StorageTarget"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "URLString": {
+      "description": "A fully qualified URL.",
+      "type": "string"
+    },
+    "UsageModel": {
+      "description": "A usage model.",
+      "properties": {
+        "display": {
+          "description": "Localized information describing this usage model.",
+          "type": "object",
+          "properties": {
+            "description": {
+              "description": "String to display for this usage model.",
+              "type": "string"
+            }
+          }
+        },
+        "modelName": {
+          "description": "Non-localized keyword name for this usage model.",
+          "type": "string"
+        },
+        "targetType": {
+          "description": "The type of Storage Target to which this model is applicable (only nfs3 as of this version).",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "UsageModelsResult": {
+      "description": "A list of Cache usage models.",
+      "properties": {
+        "nextLink": {
+          "description": "The URI to fetch the next page of Cache usage models.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The list of usage models available for the subscription.",
+          "items": {
+            "$ref": "#/definitions/UsageModel"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}


### PR DESCRIPTION
Review to address a few bugs and pbis for the swagger spec.
This will be a new version, 2020-10-01 and will eventually contain export policy updates.
For now this review covers,

Examples with root squash, mtu, encryption key, and storage target without junctions.
It also removes the discriminator usage and unused derived types leaving the specific fields in the storage target properties for each type to match the server output.